### PR TITLE
Fix: pagination doesnt work properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class Client {
 		};
 
 		if (options.page) {
-			result.start = options.page;
+			result.start = ((options.page - 1) * 10) + 1;
 		}
 
 		if (options.size) {


### PR DESCRIPTION
I've got unexpected results while working with `page` option.
`{ page: 1}` returns 1-10 results
`{ page: 2}` returns 2-11 results
etc
Fixed to:
`{ page: 1}` returns 1-10 results
`{ page: 2}` returns 11-20 results
etc